### PR TITLE
Change the course review model and fix creating course review handler

### DIFF
--- a/pages/api/reviews.ts
+++ b/pages/api/reviews.ts
@@ -1,5 +1,10 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import { createReview, deleteReview, upsertReview } from "../../services/review";
+import {
+  Course_Review_Create,
+  createReview,
+  deleteReview,
+  upsertReview,
+} from "../../services/review";
 import { Course_Review } from "@prisma/client";
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -41,7 +46,7 @@ async function handleDeleteReview(req: NextApiRequest, res: NextApiResponse) {
  */
 async function handlePostReview(req: NextApiRequest, res: NextApiResponse) {
   try {
-    const review = req.body as Course_Review;
+    const review = req.body as Course_Review_Create;
     await createReview(review);
     return res.status(200).json({ message: "Review updated" });
   } catch (err: any) {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,22 +19,22 @@ model Course {
 }
 
 model Course_Review {
-  review_id    Int       @id @default(autoincrement())
-  professor    String?
-  review       String
+  review_id    Int      @id @default(autoincrement())
+  professor    String
+  review       String?
   difficulty   Int
   liked        Boolean
   attendance   Int
-  enthusiasm   Int
+  useful       Int
   anon         Boolean
   term_taken   Term
-  date_taken   DateTime? @db.Date
-  date_created DateTime  @default(now()) @db.Timestamptz(6)
-  last_edited  DateTime  @default(now()) @db.Timestamptz(6)
-  course       Course    @relation(fields: [course_code], references: [course_code], onDelete: NoAction, onUpdate: NoAction)
-  course_code  String    @db.VarChar(255)
+  date_taken   DateTime @db.Date
+  date_created DateTime @default(now()) @db.Timestamptz(6)
+  last_edited  DateTime @default(now()) @db.Timestamptz(6)
+  course       Course   @relation(fields: [course_code], references: [course_code], onDelete: NoAction, onUpdate: NoAction)
+  course_code  String   @db.VarChar(255)
   email        String
-  user         User      @relation(fields: [email], references: [email], onDelete: NoAction, onUpdate: NoAction)
+  user         User     @relation(fields: [email], references: [email], onDelete: NoAction, onUpdate: NoAction)
 }
 
 enum Term {

--- a/services/review.ts
+++ b/services/review.ts
@@ -1,14 +1,24 @@
 import { Course_Review } from "@prisma/client";
 import { prisma } from "../lib/db";
 
+export type Course_Review_Create = Omit<
+  Course_Review,
+  "review_id" | "date_created" | "last_edited"
+>;
+
 /**
  * Create a review for a course.
  * @param review review to be created
  * @returns the review created
  */
-export function createReview(review: Course_Review) {
+export function createReview(review: Course_Review_Create) {
+  const new_review = {
+    ...review,
+    date_created: new Date(),
+    last_edited: new Date(),
+  } as Course_Review;
   return prisma.course_Review.create({
-    data: review,
+    data: new_review,
   });
 }
 


### PR DESCRIPTION
- change review schema to include useful, make professor non-optional and review column optional, and remove enthusiasm
- change the createReview function to take in a subset type of Course_Review so that the client does not have to send the review_id, date_created, and last_edited as part of the review